### PR TITLE
Update solana dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver="2"
 
 members = [
     "pyth-sdk",

--- a/examples/sol-contract/Cargo.toml
+++ b/examples/sol-contract/Cargo.toml
@@ -10,5 +10,5 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 borsh = "0.10.3"
 arrayref = "0.3.6"
-solana-program = ">= 1.10"
+solana-program = ">= 2.0.3"
 pyth-sdk-solana = { path = "../../pyth-sdk-solana", version = "0.10.0" }

--- a/pyth-sdk-solana/Cargo.toml
+++ b/pyth-sdk-solana/Cargo.toml
@@ -11,10 +11,10 @@ keywords = [ "pyth", "solana", "oracle" ]
 readme = "README.md"
 
 [dependencies]
-solana-program = ">= 1.9"
+solana-program = ">= 2.0.3"
 borsh = "0.10.3"
 borsh-derive = "0.10.3"
-bytemuck = "1.7.2"
+bytemuck = { version = "1.16.1", features = ["derive"] }
 num-derive = "0.3"
 num-traits = "0.2"
 thiserror = "1.0"
@@ -22,8 +22,8 @@ serde = { version = "1.0.136", features = ["derive"] }
 pyth-sdk = { path = "../pyth-sdk", version = "0.8.0" }
 
 [dev-dependencies]
-solana-client = ">= 1.9"
-solana-sdk = ">= 1.9"
+solana-client = ">= 2.0.3"
+solana-sdk = ">=2.0.3"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/pyth-sdk-solana/test-contract/Cargo.toml
+++ b/pyth-sdk-solana/test-contract/Cargo.toml
@@ -9,15 +9,15 @@ no-entrypoint = []
 
 [dependencies]
 pyth-sdk-solana = { path = "../", version = "0.10.0" }
-solana-program = ">= 1.10, <= 1.16"
-bytemuck = "1.7.2"
+solana-program = "2.0.3"
+bytemuck = { version = "1.16.1", features = ["derive"] }
 borsh = "0.10.3"
 borsh-derive = "0.10.3"
 
 [dev-dependencies]
-solana-program-test = ">= 1.10, <= 1.16"
-solana-client = ">= 1.10, <= 1.16"
-solana-sdk = ">= 1.10, <= 1.16"
+solana-program-test = "2.0.3"
+solana-client = "2.0.3"
+solana-sdk = "2.0.3"
 
 [lib]
 crate-type = ["cdylib", "lib"]


### PR DESCRIPTION

A step to update sablier to solana-program 2.3.0 (latest)